### PR TITLE
Slightly Better Order

### DIFF
--- a/config/nauts.lua
+++ b/config/nauts.lua
@@ -23,6 +23,7 @@ return {
 	"quack", -- rocco
 	"scissors", -- ksenia
 	"link", -- ix
+	"cowman", -- deadlift
 	"marine", -- ted
 	"scooter", -- penny
 	"phonebooth", -- sentry
@@ -32,14 +33,14 @@ return {
 	"biker", -- chucho
 	"vrooom", -- lux
 	"shutter", -- max
-	"disco", -- esc rocco
-	"yarr", -- ted pirate
-	"blblal", -- blabl zork
-	"kong", -- ronimo
-	"rock", -- rock
-	"deadlift", -- deadlift
 	"dizzy", -- dizzy
 	"dundee", -- smiles
 	"missile", -- cmdr rocket
 	"swarm", -- qi'tara
+	"disco", -- esc rocco
+	"joystick", -- 8-bit yoolip
+	"yarr", -- ted pirate
+	"blblal", -- blabl zork
+	"kong", -- ronimo
+	"rock", -- rock
 }


### PR DESCRIPTION
- Changed Deadlift to go after Ix (normal Nauts) and before Starstorm Nauts.
- Changed the Rocket Renegades to go after Overdrive and before secret characters
- Added 8-Bit Yoolip (his sprites are done, so we may as well add him)
- Gave Deadlift his ROFLname (Cowman)